### PR TITLE
rendering TODO: add a space after the keyword

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -223,7 +223,7 @@ renderTodo t =
   let comment =
         fromJust $ lookup ("." <> getExtension (sourceFile t)) fileTypeToComment
       detail =
-        T.pack "TODO(" <>
+        T.pack "TODO (" <>
         (T.pack $
          Data.String.Utils.join
            "|"


### PR DESCRIPTION
Purpose: keep compatibility with other tools, which may not parse the
TODO keyword if not separated from (metadata) by a space.