### PR TITLE
allow spaces after the TODO keyword

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -421,6 +421,7 @@ parseTodoEntryHead :: FilePath -> LineNumber -> Parser TodoEntry
 parseTodoEntryHead path lineNum = do
   entryLeadingText <- manyTill anyChar (prefixParserForFileType $ getExtension path)
   _ <- symbol "TODO"
+  space
   entryDetails <- optional $ try (inParens $ many (noneOf [')', '(']))
   let parsedDetails = parseDetails . T.pack <$> entryDetails
       entryPriority = (readMaybe . T.unpack) =<< (snd4 =<< parsedDetails)


### PR DESCRIPTION
Purpose: the parser will work correctly for all those entries:
```
-- TODO(#parser) allow spaces after the TODO keyword
-- TODO (#parser) allow spaces after the TODO keyword
-- TODO    (#parser) allow spaces after the TODO keyword
```