### PR TITLE
remove explicit dependency to bytestring

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,6 @@ import qualified Control.Exception          as E
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson
-import qualified Data.ByteString.Char8      as B8SS
 import           Data.Either
 import           Data.IORef
 import           Data.List
@@ -531,7 +530,7 @@ runFullSearch userArgs =
   in do
         configExists <- doesFileExist $ projectRoot ++ "/.toodles.yaml"
         config <- if configExists
-          then Y.decodeEither' . B8SS.pack <$> readFile (projectRoot ++ "/.toodles.yaml")
+          then Y.decodeFileEither (projectRoot ++ "/.toodles.yaml")
           else return . Right $ ToodlesConfig []
         when (isLeft config)
           $ putStrLn $ "[WARNING] Invalid .toodles.yaml: " ++ show config

--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,6 @@ executables:
     - MissingH ==1.4.0.1
     - aeson ==1.3.1.1
     - blaze-html ==0.9.1.1
-    - bytestring ==0.10.8.2
     - cmdargs ==0.10.20
     - directory ==1.3.1.5
     - filepath ==1.4.2

--- a/toodles.cabal
+++ b/toodles.cabal
@@ -47,7 +47,6 @@ executable toodles
     , aeson ==1.3.1.1
     , base >=4.0 && <5
     , blaze-html ==0.9.1.1
-    , bytestring ==0.10.8.2
     , cmdargs ==0.10.20
     , directory ==1.3.1.5
     , filepath ==1.4.2


### PR DESCRIPTION
Here is a minor change that I spotted while playing with the support for configuration files.
It removes the explicit dependency to `bytestring`.