### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,17 @@ FROM haskell:8.4
 
 VOLUME /repo
 WORKDIR /app
-ADD . /app
 
-RUN stack setup
-RUN stack build --test --copy-bins
+RUN stack update
+
+COPY toodles.cabal /app
+COPY stack.yaml /app
+
+RUN stack install --only-dependencies
+
+COPY . /app
+
+RUN stack install
 
 EXPOSE 9001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN stack install
 
 EXPOSE 9001
 
-CMD ["toodles -d /repo"]
+CMD ["toodles","-d","/repo/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,5 @@ RUN stack install
 EXPOSE 9001
 
 CMD ["toodles","-d","/repo/"]
+
+# TODO - use a multi stage build to reduce the final image size

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM haskell:8.4
+
+VOLUME /repo
+WORKDIR /app
+ADD . /app
+
+RUN stack setup
+RUN stack build --test --copy-bins
+
+EXPOSE 9001
+
+CMD ["toodles -d /repo"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ $ toodles -d /path/to/your/project -p 9001
 # or simply
 $ toodles
 ```
+#### Running with Docker
+
+For convenience this repository also provides a `Dockerfile` to automatically
+build toodles.
+
+```bash
+# to build container run:
+$ docker build -t toodles .
+# afterwards you can run the following command to execute toodles for the
+# directory you are currently in:
+$ docker run -it -v $(pwd):/repo -p 9001:9001 toodles
+
+```
 
 ### Current Limitations
 


### PR DESCRIPTION
adds a basic Dockerfile that builds and executes toodles.
Build the image with `docker build -t toodles .`
Run the image with `docker run -it -v $(pwd):/repo -p 9001:9001 toodles`

fixes #11 