### PR TITLE
add .vue files comments rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ These languages will be scanned for any TODO's:
 - Shell / Bash
 - Swift
 - Typescript
+- Vue (scripts only)
 - Yaml
 
 Submit a PR if you'd like a language to be added. There will eventually be

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -332,6 +332,7 @@ fileTypeToComment =
   , (".ts", "//")
   , (".tsx", "//")
   , (".txt", "")
+  , (".vue", "//")
   , (".yaml", "#")
   ]
 


### PR DESCRIPTION
This would add support for `.vue` files, but only in the `script` part.

I'm not sure if adding more rules like
```
, (".vue", "<!--")
, (".vue", "/*")
```
would add support for `template` and `styles`