### PR TITLE
Improve todos toggling

### DIFF
--- a/web/css/toodles.css
+++ b/web/css/toodles.css
@@ -53,6 +53,10 @@
     font-size: .75em;
 }
 
+.todo-source-link:hover {
+    font-weight: bold;    
+}
+
 .todo-source-link a:link, .todo-source-link a:visited {
     color: grey !important;
 }
@@ -75,6 +79,10 @@
     margin-right: .2em;
     padding: .3em;
     text-align: center;
+}
+
+.todo-item:hover {
+    cursor: pointer;
 }
 
 .todo-item-body {

--- a/web/css/toodles.css
+++ b/web/css/toodles.css
@@ -54,7 +54,7 @@
 }
 
 .todo-source-link:hover {
-    font-weight: bold;    
+    text-decoration: underline;
 }
 
 .todo-source-link a:link, .todo-source-link a:visited {

--- a/web/html/index.html
+++ b/web/html/index.html
@@ -130,14 +130,14 @@
                             <th>Tags</th>
                         </tr>
                     </thead>
-                    <tr class="todo-item" v-for="todo in todos" v-if="todo.body.indexOf(todoSearch) !== -1 || (todo.assignee || '').indexOf(todoSearch) !== -1 || (todo.tags || []).toString().indexOf(todoSearch) !== -1 || (todo.flag || '').indexOf(todoSearch) !== -1" @change="updateTodo('top level')">
+                    <tr class="todo-item" v-for="todo in todos" v-if="todo.body.indexOf(todoSearch) !== -1 || (todo.assignee || '').indexOf(todoSearch) !== -1 || (todo.tags || []).toString().indexOf(todoSearch) !== -1 || (todo.flag || '').indexOf(todoSearch) !== -1" @change="updateTodo('top level')" @click="toggleTodo(todo)">
                         <td><input type="checkbox" v-model="todo.selected"></td>
                         <td class="todo-item-priority" >
                             <div v-show="todo.priority !== undefined">{{ todo.priority }}</div>
                         </td>
                         <td class="todo-item-flag" >{{ todo.flag }}</td>
                         <td class='todo-item-body'>
-                            <div class="todo-source-link"><a :href="'/source_file/' + todo.id + '#line-' + todo.lineNumber" target="_blank">{{ todo.sourceFile }}:{{ todo.lineNumber}}</a></div>
+                            <div class="todo-source-link" @click="stopPropagation"><a :href="'/source_file/' + todo.id + '#line-' + todo.lineNumber" target="_blank">{{ todo.sourceFile }}:{{ todo.lineNumber}}</a></div>
                             <div>{{ todo.body }}</div>
                         </td>
                         <td class="todo-item-assignee" >{{ todo.assignee }}</td>

--- a/web/html/index.html
+++ b/web/html/index.html
@@ -37,7 +37,13 @@
                         </span>
                         <span>Delete</span>
                     </div>
-                    <div class="select-all navbar-item" v-on:click="selectAll">
+                    <div class="navbar-item deselect-all" v-on:click="deselectAll" v-show="todos.length && todos.every(t => t.selected)">
+                        <span class="icon">
+                           <i class="fa fa-square"></i> 
+                        </span>
+                        <span>Deselect All</span>
+                    </div>
+                    <div class="select-all navbar-item" v-on:click="selectAll" v-show="todos.some(t => !t.selected)">
                         <span class="icon">
                             <i class="fa fa-check-square"></i>
                         </span>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -167,6 +167,13 @@ $(document).ready(function() {
         this.hideDropdown()
       },
 
+      deselectAll: function() {
+        this.todos.map(function(t) {
+          t.selected = false
+        })
+        this.hideDropdown()
+      },
+
       toggleMenuBurger: function(ev) {
         $(".navbar-burger").toggleClass("is-active")
         $(".navbar-menu").toggleClass("is-active")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -120,6 +120,14 @@ $(document).ready(function() {
           console.log(name)
         }
       },
+      
+      toggleTodo: function(todo) {
+        todo.selected = !todo.selected
+      },
+
+      stopPropagation: function(e) {
+        e.stopPropagation()
+      },
 
       editSeletedTodos: function() {
         $(".modal").addClass("is-active")


### PR DESCRIPTION
Changes in this PR:
- Toggle todo (selected/deselected) by clicking on the todo entry in the table (when hovering the file path, font getting bold to indicate that clicking on that will open the file content and not toggle the todo).
- When all todos are selected, `Deselect All` button will appear and the `Select All` button will disappear.